### PR TITLE
feat: v4.0.2 — New Architecture support, crash fixes, CI/CD

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./gradlew clean:*)"
-    ]
-  }
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,150 @@
+name: CI
+
+on:
+  push:
+    branches: [main-v2]
+  pull_request:
+    branches: [main-v2]
+
+jobs:
+  # ─────────────────────────────────────────────
+  # Lint & TypeScript check
+  # ─────────────────────────────────────────────
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      - name: TypeScript check
+        run: yarn typescript
+
+      - name: Lint
+        run: yarn lint
+
+  # ─────────────────────────────────────────────
+  # Android build (Old Architecture)
+  # ─────────────────────────────────────────────
+  android-old-arch:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install example dependencies
+        working-directory: example
+        run: yarn install --frozen-lockfile
+
+      - name: Set OMI Maven credentials
+        run: |
+          mkdir -p ~/.gradle
+          echo "OMI_USER=${{ secrets.OMI_USER }}" >> ~/.gradle/gradle.properties
+          echo "OMI_TOKEN=${{ secrets.OMI_TOKEN }}" >> ~/.gradle/gradle.properties
+
+      - name: Build Android (Old Arch)
+        working-directory: example/android
+        run: |
+          sed -i 's/newArchEnabled=true/newArchEnabled=false/' gradle.properties
+          ./gradlew :omikit-plugin:compileDebugKotlin --no-daemon
+
+  # ─────────────────────────────────────────────
+  # Android build (New Architecture)
+  # ─────────────────────────────────────────────
+  android-new-arch:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install example dependencies
+        working-directory: example
+        run: yarn install --frozen-lockfile
+
+      - name: Set OMI Maven credentials
+        run: |
+          mkdir -p ~/.gradle
+          echo "OMI_USER=${{ secrets.OMI_USER }}" >> ~/.gradle/gradle.properties
+          echo "OMI_TOKEN=${{ secrets.OMI_TOKEN }}" >> ~/.gradle/gradle.properties
+
+      - name: Build Android (New Arch)
+        working-directory: example/android
+        run: |
+          sed -i 's/newArchEnabled=false/newArchEnabled=true/' gradle.properties
+          ./gradlew :omikit-plugin:compileDebugKotlin --no-daemon
+
+  # ─────────────────────────────────────────────
+  # iOS build (Old Architecture)
+  # ─────────────────────────────────────────────
+  ios-old-arch:
+    runs-on: macos-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install example dependencies
+        working-directory: example
+        run: yarn install --frozen-lockfile
+
+      - name: Pod install
+        working-directory: example/ios
+        run: |
+          bundle install
+          bundle exec pod install
+
+      - name: Build iOS (Old Arch)
+        working-directory: example/ios
+        run: |
+          xcodebuild build \
+            -workspace OmikitPluginExample.xcworkspace \
+            -scheme OmikitPluginExample \
+            -configuration Debug \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            | tail -20

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ OMICALL-React-Native-SDK
 log_*
 plans/*
 /plans/*
+.claude/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+example
+__tests__
+__fixtures__
+__mocks__
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.0.2 [17/03/2026]
+
+### Bug Fixes — Android Native
+- Fix build failure on RN 0.80+ / Kotlin 2.x / Gradle 8.14+ — removed `buildscript` block and `kotlin-bom:1.8.0` from library `build.gradle`
+- Fix `currentActivity!!` NPE crash in `checkAndRequestPermissions`, `requestPermissionsByCodes`, `requestPermission` — replaced with null safety
+- Fix `getBoolean()` crash when optional params omitted — added `hasKey()` guard (8 call sites)
+- Fix `checkPermissionStatus` crash from `Arguments.makeNativeMap` with nested collections — use `WritableNativeMap`
+- Fix `systemAlertWindow` / `openSystemAlertSetting` crash on pre-Marshmallow — added runtime API level guard
+- Migrate deprecated `lintOptions` → `lint`, `dataBinding` syntax for AGP 8+
+
+### Bug Fixes — JS
+- Fix `omiEmitter` undefined crash in New Architecture bridgeless mode — safe module resolution with try-catch fallback chain
+- Fix `requireNativeComponent` crash at import time in bridgeless mode — camera views (`OmiLocalCameraView`, `OmiRemoteCameraView`) now use lazy loading via Proxy
+- Fix FCM token fetch failure blocking login — wrapped in try-catch with empty string fallback
+
+### New Architecture Support
+- `omikit.tsx`: TurboModule → NativeModules → fallback resolution, safe for bridge + bridgeless mode
+- `omiEmitter`: `NativeEventEmitter(module)` → `NativeEventEmitter()` → `DeviceEventEmitter` fallback
+- Tested on RN 0.80.3 (Kotlin 2.1.20, Gradle 8.14.1) — both Old and New Architecture
+
+### Documentation
+- Add API Integration Guide for App-to-App service (`docs/api-integration-guide.md`)
+- README: Add App-to-App API section, `startServices()` usage note, VoIP/FCM setup link, Logout API warning
+- Add CHANGELOG for v4.0.2
+
+### Build & CI
+- Add GitHub Actions workflow for Android build validation on `main-v2`
+- Update `gradle.properties` defaults: compileSdk 33→35, Kotlin 1.8.20→2.0.21 (fallback only)
+
 ## 4.0.1 [09/03/2026]
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -1218,6 +1218,7 @@ if (initialCall) {
 | NativeEventEmitter warning (iOS) | Old RN bridge issue | Upgrade to v4.0.x with New Architecture |
 | `Invalid local URI` in logs | Empty proxy/host in login | Pass `host` parameter in `initCallWithUserPassword` |
 | Build error with New Arch | Codegen not configured | Ensure `codegenConfig` exists in `package.json` |
+| iOS Simulator build fails (arm64) | OmiKit binary does not include simulator slice | **iOS Simulator is not supported.** OmiKit SDK is device-only (`arm64` real device). Always build and test on a physical iOS device |
 
 ---
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,45 +1,3 @@
-// buildscript {
-//   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
-//   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["OmikitPlugin_kotlinVersion"]
-
-//   repositories {
-//     google()
-//     mavenCentral()
-//     // maven {
-//     //   url("https://vihatgroup.jfrog.io/artifactory/omi-voice/")
-//     //   credentials {
-//     //     username = "downloader"
-//     //     password = "Omi@2022"
-//     //   }
-//     // }
-//   }
-
-//   dependencies {
-//     classpath 'com.android.tools.build:gradle-api:7.1.2'
-//     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-//     classpath 'com.google.dagger:hilt-android-gradle-plugin:2.39.1'
-//     classpath 'com.github.kezong:fat-aar:1.3.8'
-//     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.29.3"
-//     classpath 'com.android.tools.build:gradle:4.0.0'
-//   }
-// }
-
-buildscript {
-    ext {
-        kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["OmikitPlugin_kotlinVersion"]
-    }
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:8.1.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.39.1'
-        classpath 'com.github.kezong:fat-aar:1.3.8'
-    }
-}
-
 def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
@@ -47,7 +5,6 @@ def isNewArchitectureEnabled() {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
-
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"
@@ -70,10 +27,11 @@ android {
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
-   buildFeatures {
-        buildConfig = true
-    }
 
+  buildFeatures {
+    buildConfig = true
+    dataBinding = true
+  }
 
   buildTypes {
     release {
@@ -81,7 +39,7 @@ android {
     }
   }
 
-  lintOptions {
+  lint {
     disable "GradleCompatible"
   }
 
@@ -90,47 +48,39 @@ android {
     targetCompatibility JavaVersion.VERSION_17
   }
 
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
-
-  dataBinding {
-    enabled = true
+  kotlinOptions {
+    jvmTarget = "17"
   }
 }
 
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
+  kotlinOptions {
+    jvmTarget = "17"
+  }
 }
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
-}
-
-
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-
-  // use for OMISDK
+  // OMISDK
   implementation("androidx.work:work-runtime:2.8.1")
   implementation "androidx.security:security-crypto:1.1.0-alpha06"
-  // api 'vn.vihat.omicall:omi-sdk:2.3.23'
   api "io.omicrm.vihat:omi-sdk:2.6.4"
 
-  implementation "com.facebook.react:react-native:+" // From node_modules
+  // React Native — resolved from consumer's node_modules
+  implementation "com.facebook.react:react-native:+"
+
+  // Kotlin
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+  // UI & Android
   implementation "com.google.android.flexbox:flexbox:3.0.0"
   implementation "androidx.appcompat:appcompat:1.6.1"
   implementation "androidx.lifecycle:lifecycle-process:2.6.1"
   implementation "com.google.android.material:material:1.9.0"
   implementation "com.google.firebase:firebase-messaging-ktx:23.1.2"
+
+  // Network
   implementation("com.squareup.retrofit2:retrofit:2.9.0") {
     exclude module: 'okhttp'
   }
@@ -140,13 +90,13 @@ dependencies {
   implementation "com.squareup.okhttp3:logging-interceptor:4.9.1"
   implementation "com.google.code.gson:gson:2.8.9"
 
-  implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
+  // Image
   implementation "com.squareup.picasso:picasso:2.8"
 
+  // Coroutines
   def coroutines_version = '1.7.2'
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
-OmikitPlugin_kotlinVersion=1.8.20
+OmikitPlugin_kotlinVersion=2.0.21
 OmikitPlugin_minSdkVersion=24
-OmikitPlugin_targetSdkVersion=33
-OmikitPlugin_compileSdkVersion=33
-OmikitPlugin_ndkversion=21.4.7075529
+OmikitPlugin_targetSdkVersion=35
+OmikitPlugin_compileSdkVersion=35
+OmikitPlugin_ndkversion=27.1.12297006

--- a/android/src/main/java/com/omikitplugin/OmikitPluginModule.kt
+++ b/android/src/main/java/com/omikitplugin/OmikitPluginModule.kt
@@ -595,22 +595,32 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
     return map
   }
 
-  @RequiresApi(Build.VERSION_CODES.M)
   @ReactMethod
   fun systemAlertWindow(promise: Promise) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      promise.resolve(true)
+      return
+    }
     val result = Settings.canDrawOverlays(reactApplicationContext)
     promise.resolve(result)
   }
 
-  @RequiresApi(Build.VERSION_CODES.M)
   @ReactMethod
   fun openSystemAlertSetting(promise: Promise) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      promise.resolve(true)
+      return
+    }
+    val ctx = reactApplicationContext ?: run {
+      promise.resolve(false)
+      return
+    }
     val intent = Intent(
       Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-      Uri.parse("package:" + reactApplicationContext.packageName)
+      Uri.parse("package:" + ctx.packageName)
     )
     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-    reactApplicationContext.startActivity(intent)
+    ctx.startActivity(intent)
     promise.resolve(true)
   }
 
@@ -638,7 +648,7 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
                 val audioNotificationDescription = data.getString("audioNotificationDescription") ?: "Cuộc gọi audio"
                 val videoNotificationDescription = data.getString("videoNotificationDescription") ?: "Cuộc gọi video"
                 val representName = data.getString("representName") ?: ""
-                val isUserBusy = data.getBoolean("isUserBusy")
+                val isUserBusy = if (data.hasKey("isUserBusy")) data.getBoolean("isUserBusy") else false
 
                 // Configure push notification with extracted parameters
                 OmiClient.getInstance(context).configPushNotification(
@@ -682,7 +692,7 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
       val password = data.getString("password")
       val realm = data.getString("realm")
       val host = data.getString("host").let { if (it.isNullOrEmpty()) "vh.omicrm.com" else it }
-      val isVideo = data.getBoolean("isVideo")
+      val isVideo = if (data.hasKey("isVideo")) data.getBoolean("isVideo") else false
       val firebaseToken = data.getString("fcmToken")
       val projectId = data.getString("projectId") ?: ""
       val isSkipDevices = if (data.hasKey("isSkipDevices")) data.getBoolean("isSkipDevices") else false
@@ -741,7 +751,7 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
       val usrName = data.getString("fullName") ?: ""
       val usrUuid = data.getString("usrUuid")  ?: ""
       val apiKey = data.getString("apiKey") ?: ""
-      val isVideo = data.getBoolean("isVideo") ?: false
+      val isVideo = if (data.hasKey("isVideo")) data.getBoolean("isVideo") else false
       val phone = data.getString("phone")
       val firebaseToken = data.getString("fcmToken") ?: ""
       val projectId = data.getString("projectId") ?: ""
@@ -898,7 +908,7 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
           promise.reject("E_INVALID_PHONE", "Phone number is required")
           return@runOnUiThread
         }
-        val isVideo = data.getBoolean("isVideo")
+        val isVideo = if (data.hasKey("isVideo")) data.getBoolean("isVideo") else false
 
         val startCallResult =
           OmiClient.getInstance(reactApplicationContext!!).startCall(phoneNumber, isVideo)
@@ -930,7 +940,7 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
     if (audio == PackageManager.PERMISSION_GRANTED) {
       mainScope.launch {
         val uuid = data.getString("usrUuid") ?: ""
-        val isVideo = data.getBoolean("isVideo")
+        val isVideo = if (data.hasKey("isVideo")) data.getBoolean("isVideo") else false
 
         val startCallResult =
           OmiClient.getInstance(reactApplicationContext!!).startCallWithUuid(uuid, isVideo)
@@ -1548,8 +1558,12 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
       // Store promise for callback
       permissionPromise = promise
       
+      val activity = reactApplicationContext?.currentActivity ?: run {
+        promise.resolve(false)
+        return
+      }
       ActivityCompat.requestPermissions(
-        reactApplicationContext.currentActivity!!,
+        activity,
         missingPermissions.toTypedArray(),
         REQUEST_PERMISSIONS_CODE,
       )
@@ -1638,15 +1652,16 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
         true
       }
       
-      permissionStatus["essentialGranted"] = grantedEssential
-      permissionStatus["essentialMissing"] = missingEssential
-      permissionStatus["canMakeVoipCalls"] = missingEssential.isEmpty()
-      permissionStatus["foregroundServicePermissions"] = foregroundServiceStatus
-      permissionStatus["canDrawOverlays"] = canDrawOverlays
-      permissionStatus["androidVersion"] = Build.VERSION.SDK_INT
-      permissionStatus["targetSdk"] = reactApplicationContext.applicationInfo.targetSdkVersion
-      
-      val map = Arguments.makeNativeMap(permissionStatus)
+      val map: WritableMap = WritableNativeMap()
+      map.putArray("essentialGranted", Arguments.fromList(grantedEssential.toList()))
+      map.putArray("essentialMissing", Arguments.fromList(missingEssential.toList()))
+      map.putBoolean("canMakeVoipCalls", missingEssential.isEmpty())
+      val fgServiceMap: WritableMap = WritableNativeMap()
+      foregroundServiceStatus.forEach { (k, v) -> fgServiceMap.putBoolean(k, v) }
+      map.putMap("foregroundServicePermissions", fgServiceMap)
+      map.putBoolean("canDrawOverlays", canDrawOverlays)
+      map.putInt("androidVersion", Build.VERSION.SDK_INT)
+      map.putInt("targetSdk", reactApplicationContext.applicationInfo.targetSdkVersion)
       promise.resolve(map)
       
     } catch (e: Exception) {
@@ -1721,8 +1736,12 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
       // Store promise for callback
       permissionPromise = promise
       
+      val activity = reactApplicationContext?.currentActivity ?: run {
+        promise.reject("E_NULL_ACTIVITY", "Current activity is null")
+        return
+      }
       ActivityCompat.requestPermissions(
-        reactApplicationContext.currentActivity!!,
+        activity,
         permissionsToRequest.toTypedArray(),
         REQUEST_PERMISSIONS_CODE
       )
@@ -1734,19 +1753,20 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
 
   private fun requestPermission(isVideo: Boolean) {
     val missingPermissions = getMissingPermissions(isVideo)
-    
+
     if (missingPermissions.isEmpty()) {
       return
     }
-    
+
+    val activity = reactApplicationContext?.currentActivity ?: return
     ActivityCompat.requestPermissions(
-      reactApplicationContext.currentActivity!!,
+      activity,
       missingPermissions.toTypedArray(),
       REQUEST_PERMISSIONS_CODE,
     )
   }
 
-  override fun onActivityResult(p0: Activity?, requestCode: Int, resultCode: Int, p3: Intent?) {
+  override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
     if (requestCode == REQUEST_OVERLAY_PERMISSION_CODE) {
       val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         Settings.canDrawOverlays(reactApplicationContext)
@@ -1758,14 +1778,12 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
     }
   }
 
-  override fun onNewIntent(p0: Intent?) {
-    if (p0 != null && p0.hasExtra(SipServiceConstants.PARAM_IS_MISSED_CALL)) {
-      //do your Stuff
-
-      if (p0.getBooleanExtra(SipServiceConstants.PARAM_IS_MISSED_CALL, false)) {
+  override fun onNewIntent(intent: Intent) {
+    if (intent.hasExtra(SipServiceConstants.PARAM_IS_MISSED_CALL)) {
+      if (intent.getBooleanExtra(SipServiceConstants.PARAM_IS_MISSED_CALL, false)) {
         val map: WritableMap = WritableNativeMap()
-        map.putString("callerNumber", p0.getStringExtra(SipServiceConstants.PARAM_NUMBER) ?: "")
-        map.putBoolean("isVideo", p0.getBooleanExtra(SipServiceConstants.PARAM_IS_VIDEO, false))
+        map.putString("callerNumber", intent.getStringExtra(SipServiceConstants.PARAM_NUMBER) ?: "")
+        map.putBoolean("isVideo", intent.getBooleanExtra(SipServiceConstants.PARAM_IS_VIDEO, false))
         sendEvent(CLICK_MISSED_CALL, map)
       }
     }
@@ -1916,11 +1934,11 @@ class OmikitPluginModule(reactContext: ReactApplicationContext?) :
       val password = data.getString("password")
       val realm = data.getString("realm")
       val host = data.getString("host").let { if (it.isNullOrEmpty()) "vh.omicrm.com" else it }
-      val isVideo = data.getBoolean("isVideo")
+      val isVideo = if (data.hasKey("isVideo")) data.getBoolean("isVideo") else false
       val firebaseToken = data.getString("fcmToken")
       val projectId = data.getString("projectId") ?: ""
-      val showNotification = data.getBoolean("showNotification") ?: true
-      val enableAutoUnregister = data.getBoolean("enableAutoUnregister") ?: true
+      val showNotification = if (data.hasKey("showNotification")) data.getBoolean("showNotification") else true
+      val enableAutoUnregister = if (data.hasKey("enableAutoUnregister")) data.getBoolean("enableAutoUnregister") else true
 
       // Validate required parameters
       if (userName.isNullOrEmpty() || password.isNullOrEmpty() || realm.isNullOrEmpty() || firebaseToken.isNullOrEmpty()) {

--- a/example/src/login.tsx
+++ b/example/src/login.tsx
@@ -47,10 +47,10 @@ import { CustomLoading } from './components/custom_view/custom_loading';
 // Default credentials for testing
 const DEFAULT_CREDENTIALS = {
   realm: 'luuphuongmytrinh9a2',
-  userName: '100',
-  password: 'iT2OjDYA0H',
+  userName: '101',
+  password: 'vivx2001@A',
   host: 'vh.omicrm.com',
-  projectId: 'omicrm-6558a',
+  projectId: '',
 };
 
 // Error messages mapping for user-friendly display
@@ -240,7 +240,7 @@ export const LoginScreen = () => {
         fcmToken: fcmToken || '',
         projectId: DEFAULT_CREDENTIALS.projectId,
       };
-      
+
       console.log('[LOGIN] Step 2: Login info prepared:', JSON.stringify({
         ...loginInfo,
         password: '***',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omikit-plugin",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Omikit Plugin by ViHAT",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/omi_local_camera.tsx
+++ b/src/omi_local_camera.tsx
@@ -1,16 +1,21 @@
 import type { HostComponent } from 'react-native';
 import { NativeModules, requireNativeComponent, ViewProps } from 'react-native';
 
-// Camera Views always use Paper (requireNativeComponent) because:
-// - iOS native code doesn't have Fabric ComponentView implementation yet
-// - Paper components work fine even when New Architecture is enabled
-// - This avoids undefined symbol errors (_FLLocalCameraViewCls)
-const OmiLocalCameraViewPaper: HostComponent<ViewProps> = requireNativeComponent(
-  'FLLocalCameraView'
-);
+// Safe lazy loading — requireNativeComponent can throw in bridgeless mode
+// if the native view is not registered for Fabric
+let _localCameraView: HostComponent<ViewProps> | null = null;
+const getLocalCameraView = (): HostComponent<ViewProps> => {
+  if (!_localCameraView) {
+    _localCameraView = requireNativeComponent('FLLocalCameraView');
+  }
+  return _localCameraView;
+};
 
-// Export the Paper component
-export const OmiLocalCameraView: HostComponent<ViewProps> = OmiLocalCameraViewPaper;
+export const OmiLocalCameraView = new Proxy({} as HostComponent<ViewProps>, {
+  get(_target, prop) {
+    return (getLocalCameraView() as any)[prop];
+  },
+});
 
 // Module name separated from ViewManager name to avoid name collision
 const FLLocalCamera = NativeModules.FLLocalCameraModule || NativeModules.FLLocalCameraView;

--- a/src/omi_remote_camera.tsx
+++ b/src/omi_remote_camera.tsx
@@ -1,16 +1,21 @@
 import type { HostComponent } from 'react-native';
 import { NativeModules, requireNativeComponent, ViewProps } from 'react-native';
 
-// Camera Views always use Paper (requireNativeComponent) because:
-// - iOS native code doesn't have Fabric ComponentView implementation yet
-// - Paper components work fine even when New Architecture is enabled
-// - This avoids undefined symbol errors (_FLRemoteCameraViewCls)
-const OmiRemoteCameraViewPaper: HostComponent<ViewProps> = requireNativeComponent(
-  'FLRemoteCameraView'
-);
+// Safe lazy loading — requireNativeComponent can throw in bridgeless mode
+// if the native view is not registered for Fabric
+let _remoteCameraView: HostComponent<ViewProps> | null = null;
+const getRemoteCameraView = (): HostComponent<ViewProps> => {
+  if (!_remoteCameraView) {
+    _remoteCameraView = requireNativeComponent('FLRemoteCameraView');
+  }
+  return _remoteCameraView;
+};
 
-// Export the Paper component
-export const OmiRemoteCameraView: HostComponent<ViewProps> = OmiRemoteCameraViewPaper;
+export const OmiRemoteCameraView = new Proxy({} as HostComponent<ViewProps>, {
+  get(_target, prop) {
+    return (getRemoteCameraView() as any)[prop];
+  },
+});
 
 // Module name separated from ViewManager name to avoid name collision
 const FLRemoteCamera = NativeModules.FLRemoteCameraModule || NativeModules.FLRemoteCameraView;

--- a/src/omikit.tsx
+++ b/src/omikit.tsx
@@ -7,39 +7,52 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
-// Runtime detection: Try TurboModule first, fallback to NativeModule
-const isTurboModuleEnabled = (global as any).__turboModuleProxy != null;
-
-const OmikitPlugin: Spec = (() => {
-  if (isTurboModuleEnabled) {
-    // New Architecture - use TurboModule
+// Resolve native module: TurboModule (New Arch) → NativeModules (Old Arch) → null
+const resolvedModule: Spec | null = (() => {
+  try {
+    // Try TurboModule first (New Architecture / bridgeless mode)
     const turboModule = TurboModuleRegistry.get<Spec>('OmikitPlugin');
-    if (turboModule) {
-      return turboModule;
-    }
+    if (turboModule) return turboModule;
+  } catch (_) {}
+
+  // Fallback to NativeModules (Old Architecture / bridge mode)
+  if (NativeModules.OmikitPlugin) {
+    return NativeModules.OmikitPlugin;
   }
 
-  // Old Architecture - fallback to NativeModule
-  return NativeModules.OmikitPlugin || new Proxy(
-    {},
-    {
-      get() {
-        throw new Error(LINKING_ERROR);
-      },
-    }
-  );
+  return null;
 })();
 
-// Setup omiEmitter for iOS and Android
-// In bridgeless mode, NativeModules is empty — use TurboModule instance instead
-const omiEmitter = Platform.OS === 'ios'
-  ? new NativeEventEmitter(
-      (NativeModules.OmikitPlugin ?? OmikitPlugin ?? {
-        addListener: () => {},
-        removeListeners: () => {},
-      }) as any
-    )
-  : DeviceEventEmitter;
+// Wrap in Proxy that throws LINKING_ERROR only when SDK methods are actually called
+const OmikitPlugin: Spec = resolvedModule || new Proxy(
+  {} as Spec,
+  {
+    get(_target, prop) {
+      if (prop === 'addListener' || prop === 'removeListeners') {
+        return () => {};
+      }
+      throw new Error(LINKING_ERROR);
+    },
+  }
+);
+
+// Setup omiEmitter — safe for Old Arch, New Arch, and bridgeless mode
+const omiEmitter = (() => {
+  if (Platform.OS !== 'ios') {
+    return DeviceEventEmitter;
+  }
+  try {
+    // Best case: NativeEventEmitter with resolved native module
+    if (resolvedModule) {
+      return new NativeEventEmitter(resolvedModule as any);
+    }
+    // New Arch without interop: NativeEventEmitter without module arg (RN 0.74+)
+    return new NativeEventEmitter();
+  } catch (_) {
+    // Last resort fallback
+    return DeviceEventEmitter;
+  }
+})();
 
 /**
  * Starts the Omikit services.


### PR DESCRIPTION
- Fix build failure on RN 0.80+ / Kotlin 2.x / Gradle 8.14+
- Fix Android crashes: currentActivity NPE, getBoolean NoSuchKeyException, nested Map in checkPermissionStatus, systemAlertWindow pre-M crash
- Add New Architecture (bridgeless) support: safe module resolution, lazy camera view loading, omiEmitter fallback chain
- Add GitHub Actions CI for main-v2 (lint, Android old/new arch, iOS)
- Add API Integration Guide (docs/api-integration-guide.md)
- Update README: App-to-App API, startServices note, iOS simulator note
- Add CHANGELOG for v4.0.2
- Remove .claude from git tracking