### PR TITLE
Release v4.2.3 — bump OmiKit iOS 1.11.29 + omi-sdk Android 2.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.2.3 [29/07/2026]
+
+### Upgrade — native SDK
+
+- **[UPGRADE] iOS `OmiKit 1.11.26 → 1.11.29`.**
+- **[UPGRADE] Android `omi-sdk 2.7.4 → 2.7.7`.**
+
 ## 4.2.2 [20/07/2026]
 
 ### Upgrade — native SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## 4.2.1 [16/07/2026]
+## 4.2.2 [20/07/2026]
+
+### Upgrade — native SDK
+
+- **[UPGRADE] iOS `OmiKit 1.11.25 → 1.11.26`.**
 
 ### Fix — Expo iOS: OmiKit env/CallKit/PushKit never initialized on apps with many pods (calls fail with staging host)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,7 +83,7 @@ dependencies {
   // OMISDK
   implementation("androidx.work:work-runtime:2.8.1")
   implementation "androidx.security:security-crypto:1.1.0-alpha06"
-  api "io.omicrm.vihat:omi-sdk:2.7.4"
+  api "io.omicrm.vihat:omi-sdk:2.7.7"
 
   // React Native — resolved from consumer's node_modules
   implementation "com.facebook.react:react-native:+"

--- a/omikit-plugin.podspec
+++ b/omikit-plugin.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   # Apple Silicon — no need to exclude arm64 for the simulator anymore.
   # (Excluding it forced x86_64/Rosetta and dropped our Swift .o files from the
   #  simulator binary, which broke the Expo lifecycle subscriber's +load.)
-  s.dependency "OmiKit", "1.11.25"
+  s.dependency "OmiKit", "1.11.26"
 
   # Base xcconfig applied regardless of architecture
   base_xcconfig = {

--- a/omikit-plugin.podspec
+++ b/omikit-plugin.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   # Apple Silicon — no need to exclude arm64 for the simulator anymore.
   # (Excluding it forced x86_64/Rosetta and dropped our Swift .o files from the
   #  simulator binary, which broke the Expo lifecycle subscriber's +load.)
-  s.dependency "OmiKit", "1.11.26"
+  s.dependency "OmiKit", "1.11.29"
 
   # Base xcconfig applied regardless of architecture
   base_xcconfig = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omikit-plugin",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Omikit Plugin by ViHAT",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omikit-plugin",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Omikit Plugin by ViHAT",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Release v4.2.3

Bumps the native SDK versions (published to npm as 4.2.3).

### Changes
- **v4.2.2** — `chore(release)`: bump OmiKit iOS 1.11.25 → 1.11.26
- **v4.2.3** — `chore(release)`: bump OmiKit iOS 1.11.26 → 1.11.29, omi-sdk Android 2.7.4 → 2.7.7

Both native SDK versions verified to exist on their repos (OmiKit on CocoaPods trunk, omi-sdk on GitHub Packages) before publishing.

No code changes — version bumps only. The Expo AppDelegate race fix landed earlier in v4.2.1 (PR #20).

### Verification
- `yarn build:plugin` — clean
- `yarn test:plugin` — 20/20 pass
- npm: `omikit-plugin@4.2.3` published